### PR TITLE
feat: add strains dispatcher workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A centralized spot for all your reusable GitHub Actions workflows and custom act
 | Name                         | Description                                                          | File Path                                                       |
 |------------------------------|----------------------------------------------------------------------|-----------------------------------------------------------------|
 | **MFE S3 Bucket Deployment** | Builds and deploys Micro-Frontend apps to AWS S3 with ease.          | [mfe-s3-bucket-deployment/action.yml](mfe-s3-bucket-deployment/action.yml) |
+| **Strain Repo Dispatch**     | Kicks off strain updates whenever certain repository events happen.  | [strain-repo-dispatch/action.yml](strain-repo-dispatch/action.yml) |
 
 ## Using Actions from Organization Repositories
 

--- a/strain-repo-dispatch/action.yml
+++ b/strain-repo-dispatch/action.yml
@@ -1,0 +1,50 @@
+name: Strain Repo Dispatch 📜
+
+on:
+  workflow_call:
+    inputs:
+      STRAIN_PROPERTY:
+        description: Strain property value
+        required: true
+        type: string
+      STRAIN_PATH:
+        description: Path for the strain
+        required: true
+        type: string
+    secrets:
+      ROBONEXT_PAT:
+        description: Personal access token for repository dispatch
+        required: true
+
+jobs:
+  strain-dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Manipulate strain property if necessary
+        run: |
+          echo "STRAIN_PROPERTY=${{ inputs.STRAIN_PROPERTY }}" >> $GITHUB_ENV
+
+      - name: Strain Repository Dispatch
+        if: |
+          github.event.action == 'opened' ||
+          github.event.action == 'synchronize' ||
+          (github.event.action == 'closed' && github.event.pull_request.merged)
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.ROBONEXT_PAT }}
+          repository: nelc/edx-platform-strains
+          event-type: strain-update-pr
+          client-payload: |
+            {
+              "repo": "${{ github.repository }}",
+              "sha": "${{ github.event.pull_request.head.sha }}",
+              "head_ref": "${{ github.head_ref }}",
+              "base_ref": "${{ github.base_ref }}",
+              "strain_property": "${{ env.STRAIN_PROPERTY }}",
+              "strain_property_value": "${{ env.PROPERTY_VALUE }}",
+              "strain_path": "${{ inputs.STRAIN_PATH }}",
+              "pr_number": "${{ github.event.number }}",
+              "pr_action": "${{ github.event.action }}"
+            }
+        env:
+          PROPERTY_VALUE: ${{ github.event.pull_request.merged && github.base_ref || github.head_ref }}


### PR DESCRIPTION
## Description

This PR adds the Strain Dispatcher workflow to the Actions Hub, centralizing its configuration. There are no major changes—only the workflow inputs have been defined and renamed for improved clarity.

## How to call the workflow
Include the following snippet in your GitHub Actions workflow file to call the reusable workflow:

```yaml
jobs:
  strain-dispatch-job:
    uses: nelc-actions-hub/strain-repo-dispatch/action.yml@v1.0.0
    with:
      STRAIN_PROPERTY: 'your-strain-property-value'
      STRAIN_PATH: 'your-strain-path'
    secrets:
      ROBONEXT_PAT: ${{ secrets.ROBONEXT_PAT }}
