### PR TITLE
fix: adjust mfe-deploy workflow environment parameters

### DIFF
--- a/.github/workflows/mfe-s3-bucket-deployment.yml
+++ b/.github/workflows/mfe-s3-bucket-deployment.yml
@@ -3,67 +3,27 @@ name: MFE S3 Bucket Deployment 🚀
 on:
   workflow_call:
     inputs:
-      NODE_VERSION:
-        description: The Node.js version to use
-        required: true
-        type: string
-      ATLAS_OPTIONS:
-        description: Options for pulling translations (if needed)
-        required: false
-        type: string
-        default: ""
-      PUBLIC_PATH_CDN:
-        description: The public CDN path for deployment
-        required: true
-        type: string
-      APP_ID:
-        description: Application ID used for naming and identification
-        required: true
-        type: string
-      MFE_CONFIG_API_URL:
-        description: Configuration API URL for the MFE
-        required: true
-        type: string
-      BUCKET_NAME:
-        description: S3 bucket name (without s3:// prefix)
-        required: true
-        type: string
       PROD_BRANCH:
-        description: The production branch name
-        required: true
-        type: string
-
-    secrets:
-      AWS_ACCESS_KEY_ID:
-        description: AWS Access Key ID
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        description: AWS Secret Access Key
-        required: true
-      AWS_DEFAULT_REGION:
-        description: AWS default region
-        required: true
-      AWS_CLOUDFRONT_DISTRIBUTION_ID:
-        description: AWS CloudFront Distribution ID
+        description: 'Production branch name'
         required: true
 
 jobs:
   build:
     environment:
-      name: ${{ github.ref_name == inputs.PROD_BRANCH && 'prod' || 'stage' }}
+      name:  ${{ github.ref_name == inputs.PROD_BRANCH && 'prod' || 'stage' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Echo workflow inputs for debugging
+      - name: Echo workflow vars for debugging
         run: |
-          echo "Inputs: ${{ toJson(inputs) }}"
+          echo "variables: ${{ toJson(vars) }}"
 
       - name: Checkout MFE repository
         uses: actions/checkout@v4
 
-      - name: Set up Node.js ${{ inputs.NODE_VERSION }}
+      - name: Set up Node.js ${{ vars.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ inputs.NODE_VERSION }}
+          node-version: ${{ vars.NODE_VERSION }}
 
       - name: Cache node modules
         id: cache-npm
@@ -87,17 +47,17 @@ jobs:
         run: npm install
 
       - name: Pull translations
-        if: ${{ inputs.ATLAS_OPTIONS != '' }}
+        if: ${{ vars.ATLAS_OPTIONS != '' }}
         run: |
           export PATH="$(pwd)/node_modules/.bin:$PATH"
-          make OPENEDX_ATLAS_PULL=true ATLAS_OPTIONS="${{ inputs.ATLAS_OPTIONS }}" pull_translations
+          make OPENEDX_ATLAS_PULL=true ATLAS_OPTIONS="${{ vars.ATLAS_OPTIONS }}" pull_translations
 
       - name: Build the application
         run: npm run build
         env:
-          PUBLIC_PATH: ${{ inputs.PUBLIC_PATH_CDN }}
-          APP_ID: ${{ inputs.APP_ID }}
-          MFE_CONFIG_API_URL: ${{ inputs.MFE_CONFIG_API_URL }}
+          PUBLIC_PATH: ${{ vars.PUBLIC_PATH_CDN }}
+          APP_ID: ${{ vars.APP_ID }}
+          MFE_CONFIG_API_URL: ${{ vars.MFE_CONFIG_API_URL }}
           ENABLE_NEW_RELIC: false
           NODE_ENV: production
 
@@ -107,24 +67,24 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.APP_ID }}-dist-artifact
+          name: ${{ vars.APP_ID }}-dist-artifact
           path: dist
 
   deployment:
     environment:
       name: ${{ github.ref_name == inputs.PROD_BRANCH && 'prod' || 'stage' }}
-      url: ${{ inputs.PUBLIC_PATH_CDN }}
+      url: ${{ vars.PUBLIC_PATH_CDN }}
     runs-on: ubuntu-latest
     needs: build
     steps:
       - name: Download build artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.APP_ID }}-dist-artifact
+          name: ${{ vars.APP_ID }}-dist-artifact
 
-      - name: Echo workflow inputs for debugging
+      - name: Echo workflow vars for debugging
         run: |
-          echo "Inputs: ${{ toJson(inputs) }}"
+          echo "variables: ${{ toJson(vars) }}"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
@@ -137,10 +97,10 @@ jobs:
         run: |
           aws s3 sync . $S3_BUCKET --delete
         env:
-          S3_BUCKET: s3://${{ inputs.BUCKET_NAME }}/${{ inputs.APP_ID }}/
+          S3_BUCKET: s3://${{ vars.BUCKET_NAME }}/${{ vars.APP_ID }}/
 
       - name: Invalidate CloudFront cache
         run: |
           aws cloudfront create-invalidation \
             --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }} \
-            --paths "/${{ inputs.APP_ID }}/*"
+            --paths "/${{ vars.APP_ID }}/*"

--- a/.github/workflows/mfe-s3-bucket-deployment.yml
+++ b/.github/workflows/mfe-s3-bucket-deployment.yml
@@ -4,13 +4,14 @@ on:
   workflow_call:
     inputs:
       PROD_BRANCH:
-        description: 'Production branch name'
+        description: Production branch name
+        type: string
         required: true
 
 jobs:
   build:
     environment:
-      name:  ${{ github.ref_name == inputs.PROD_BRANCH && 'prod' || 'stage' }}
+      name: ${{ github.ref_name == inputs.PROD_BRANCH && 'prod' || 'stage' }}
     runs-on: ubuntu-latest
     steps:
       - name: Echo workflow vars for debugging

--- a/.github/workflows/mfe-s3-bucket-deployment.yml
+++ b/.github/workflows/mfe-s3-bucket-deployment.yml
@@ -1,3 +1,29 @@
+# MFE S3 Bucket Deployment Workflow
+
+# PURPOSE:
+#   This workflow builds and deploys a Micro Frontend (MFE) application to an AWS S3 bucket
+
+# TRIGGER:
+#   This is a reusable workflow that can be called from other workflows using workflow_call.
+#
+# INPUTS:
+#   - PROD_BRANCH: Name of the production branch (required) - used to determine environment
+
+# REQUIRED GITHUB VARIABLES (vars):
+#   - BUCKET_NAME: The name of the S3 bucket where the MFE will be deployed | ** Env Based **
+#   - PUBLIC_PATH_CDN: The CDN URL where the MFE will be hosted | ** Env Based **
+#   - NODE_VERSION: Version of Node.js to use for building
+#   - APP_ID: The ID/name of the MFE application
+#   - MFE_CONFIG_API_URL: The API URL for the MFE configuration
+#   - ATLAS_OPTIONS: Optional. Configuration for translation pulling (if empty, step is skipped)
+
+# REQUIRED SECRETS:
+#   - AWS_ACCESS_KEY_ID: AWS access key ID with permissions to deploy to S3 | ** Env Based **
+#   - AWS_SECRET_ACCESS_KEY: AWS secret access key | ** Env Based **
+#   - AWS_DEFAULT_REGION: AWS region where the S3 bucket is located | ** Env Based **
+#   - AWS_CLOUDFRONT_DISTRIBUTION_ID: CloudFront distribution ID for cache invalidation | ** Env Based **
+
+
 name: MFE S3 Bucket Deployment 🚀
 
 on:


### PR DESCRIPTION
## Problem  
In GitHub Actions, `vars` and `secrets` are evaluated based on the environment specified when calling a job using the `environment:` key. However, according to GitHub's official documentation, reusable workflows do not currently support defining environments at initialization. [Reference](https://docs.github.com/en/enterprise-cloud@latest/actions/sharing-automations/reusing-workflows#supported-keywords-for-jobs-that-call-a-reusable-workflow).  

## Changes  
To address this limitation, the reusable workflow must access `vars` and `secrets` directly, as inputs from the caller workflow will not be populated due to the missing environment.  

### Updates:  
- Removed all input fields.  
- Accessed `secrets` and `vars` directly from the job instead of relying on caller inputs.  
